### PR TITLE
Base error definition is extracted into a separate file in the common division

### DIFF
--- a/cfg_errors.go
+++ b/cfg_errors.go
@@ -33,15 +33,6 @@ var (
 	nodeCannotHaveChildrenError = errors.New("Node cannot have children")
 )
 
-// Base struct for custom errors.
-type baseError struct {
-	message string
-}
-
-func (be baseError) Error() string {
-	return be.message
-}
-
 type unexpectedChildElementError struct {
 	baseError
 }

--- a/common_errors.go
+++ b/common_errors.go
@@ -1,0 +1,10 @@
+package seelog
+
+// Base struct for custom errors.
+type baseError struct {
+    message string
+}
+
+func (be baseError) Error() string {
+    return be.message
+}


### PR DESCRIPTION
Cosmetics for cfg errors
