### PR TITLE
Add some functions to make replacing default log package easier.

### DIFF
--- a/log.go
+++ b/log.go
@@ -181,6 +181,13 @@ func Infof(format string, params ...interface{}) {
 	Current.infoWithCallDepth(staticFuncCallDepth, newLogFormattedMessage(format, params))
 }
 
+// Printf formats message according to format specifier and writes to default logger with log level = Info
+func Printf(format string, params ...interface{}) {
+	pkgOperationsMutex.Lock()
+	defer pkgOperationsMutex.Unlock()
+	Current.infoWithCallDepth(staticFuncCallDepth, newLogFormattedMessage(format, params))
+}
+
 // Warnf formats message according to format specifier and writes to default logger with log level = Warn
 func Warnf(format string, params ...interface{}) {
 	pkgOperationsMutex.Lock()
@@ -218,6 +225,13 @@ func Debug(v ...interface{}) {
 
 // Info formats message using the default formats for its operands and writes to default logger with log level = Info
 func Info(v ...interface{}) {
+	pkgOperationsMutex.Lock()
+	defer pkgOperationsMutex.Unlock()
+	Current.infoWithCallDepth(staticFuncCallDepth, newLogMessage(v))
+}
+
+// Println formats message using the default formats for its operands and writes to default logger with log level = Info
+func Println(v ...interface{}) {
 	pkgOperationsMutex.Lock()
 	defer pkgOperationsMutex.Unlock()
 	Current.infoWithCallDepth(staticFuncCallDepth, newLogMessage(v))


### PR DESCRIPTION
I've simply copied the Info/Infof functions as Println/Printf, this allows easier transition from the standard log package.
