### PR TITLE
Add FuncShort format alias

### DIFF
--- a/format.go
+++ b/format.go
@@ -67,6 +67,7 @@ var verbFuncs = map[string]verbFunc{
 	"File":     verbFile,
 	"RelFile":  verbRelFile,
 	"Func":     verbFunction,
+	"FuncShort":verbFunctionShort,
 	"Line":     verbLine,
 	"Time":     verbTime,
 	"Ns":       verbNs,
@@ -330,6 +331,12 @@ func verbRelFile(message string, level LogLevel, context logContextInterface) in
 
 func verbFunction(message string, level LogLevel, context logContextInterface) interface{} {
 	return context.Func()
+}
+
+func verbFunctionShort(message string, level LogLevel, context logContextInterface) interface{} {
+	f := context.Func()
+	spl := strings.Split(f, ".")
+	return spl[len(spl) - 1]
 }
 
 func verbLine(message string, level LogLevel, context logContextInterface) interface{} {

--- a/format_test.go
+++ b/format_test.go
@@ -150,8 +150,8 @@ func TestFormats(t *testing.T) {
 		msg := form.Format(test.input, test.inputLogLevel, context)
 
 		if err == nil && msg != test.expectedOutput {
-			t.Errorf("Input: %s \nInput LL: %s\n* Expected: %s \n* Got: %s\n", test.input,
-				test.inputLogLevel, test.expectedOutput, msg)
+			t.Errorf("Format: %s \nInput: %s \nInput LL: %s\n* Expected: %s \n* Got: %s\n", 
+				test.formatString, test.input,	test.inputLogLevel, test.expectedOutput, msg)
 		}
 	}
 }


### PR DESCRIPTION
Create '%FuncShort' format alias, that would act like the '%Func' shortcut, but in case func name is long (e.g. functions from other packages have full names, including package), it would show only the part after the last dot ('.') in the name.

Example:

%Func -> 'somepackage.somestr.somefunc'
%FuncShort -> 'somefunc'
