### PR TITLE
Error returning for easier migrations from log4go

### DIFF
--- a/log.go
+++ b/log.go
@@ -114,12 +114,12 @@ func createLoggerFromConfig(config *logConfig) (LoggerInterface, error) {
 	return nil, errors.New("Invalid config log type/data")
 }
 
-// UseLogger sets the 'Current' package level logger variable to the specified value. 
+// UseLogger sets the 'Current' package level logger variable to the specified value.
 // This variable is used in all Trace/Debug/... package level convenience funcs.
-// 
-// Example: 
 //
-// after calling 
+// Example:
+//
+// after calling
 //     seelog.UseLogger(somelogger)
 // the following:
 //     seelog.Debug("abc")
@@ -154,18 +154,18 @@ func UseLogger(logger LoggerInterface) error {
 //
 // Example:
 //     import log "github.com/cihub/seelog"
-//     
+//
 //     func main() {
 //         logger, err := log.LoggerFromConfigAsFile("seelog.xml")
-//     
+//
 //         if err != nil {
 //             panic(err)
 //         }
-//     
+//
 //         log.ReplaceLogger(logger)
 //         defer log.Flush()
-//     
-//         log.Trace("test") 
+//
+//         log.Trace("test")
 //         log.Debugf("var = %s", "abc")
 //     }
 func ReplaceLogger(logger LoggerInterface) error {
@@ -219,24 +219,30 @@ func Infof(format string, params ...interface{}) {
 }
 
 // Warnf formats message according to format specifier and writes to default logger with log level = Warn
-func Warnf(format string, params ...interface{}) {
+func Warnf(format string, params ...interface{}) error {
 	pkgOperationsMutex.Lock()
 	defer pkgOperationsMutex.Unlock()
-	Current.warnWithCallDepth(staticFuncCallDepth, newLogFormattedMessage(format, params))
+	message := newLogFormattedMessage(format, params)
+	Current.warnWithCallDepth(staticFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 // Errorf formats message according to format specifier and writes to default logger with log level = Error
-func Errorf(format string, params ...interface{}) {
+func Errorf(format string, params ...interface{}) error {
 	pkgOperationsMutex.Lock()
 	defer pkgOperationsMutex.Unlock()
-	Current.errorWithCallDepth(staticFuncCallDepth, newLogFormattedMessage(format, params))
+	message := newLogFormattedMessage(format, params)
+	Current.errorWithCallDepth(staticFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 // Criticalf formats message according to format specifier and writes to default logger with log level = Critical
-func Criticalf(format string, params ...interface{}) {
+func Criticalf(format string, params ...interface{}) error {
 	pkgOperationsMutex.Lock()
 	defer pkgOperationsMutex.Unlock()
-	Current.criticalWithCallDepth(staticFuncCallDepth, newLogFormattedMessage(format, params))
+	message := newLogFormattedMessage(format, params)
+	Current.criticalWithCallDepth(staticFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 // Trace formats message using the default formats for its operands and writes to default logger with log level = Trace
@@ -261,28 +267,34 @@ func Info(v ...interface{}) {
 }
 
 // Warn formats message using the default formats for its operands and writes to default logger with log level = Warn
-func Warn(v ...interface{}) {
+func Warn(v ...interface{}) error {
 	pkgOperationsMutex.Lock()
 	defer pkgOperationsMutex.Unlock()
-	Current.warnWithCallDepth(staticFuncCallDepth, newLogMessage(v))
+	message := newLogMessage(v)
+	Current.warnWithCallDepth(staticFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 // Error formats message using the default formats for its operands and writes to default logger with log level = Error
-func Error(v ...interface{}) {
+func Error(v ...interface{}) error {
 	pkgOperationsMutex.Lock()
 	defer pkgOperationsMutex.Unlock()
-	Current.errorWithCallDepth(staticFuncCallDepth, newLogMessage(v))
+	message := newLogMessage(v)
+	Current.errorWithCallDepth(staticFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 // Critical formats message using the default formats for its operands and writes to default logger with log level = Critical
-func Critical(v ...interface{}) {
+func Critical(v ...interface{}) error {
 	pkgOperationsMutex.Lock()
 	defer pkgOperationsMutex.Unlock()
-	Current.criticalWithCallDepth(staticFuncCallDepth, newLogMessage(v))
+	message := newLogMessage(v)
+	Current.criticalWithCallDepth(staticFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 // Flush immediately processes all currently queued messages and all currently buffered messages.
-// It is a blocking call which returns only after the queue is empty and all the buffers are empty. 
+// It is a blocking call which returns only after the queue is empty and all the buffers are empty.
 //
 // If Flush is called for a synchronous logger (type='sync'), it only flushes buffers (e.g. '<buffered>' receivers)
 // , because there is no queue.

--- a/logger.go
+++ b/logger.go
@@ -1,16 +1,16 @@
 // Copyright (c) 2012 - Cloud Instruments Co., Ltd.
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,6 +25,7 @@
 package seelog
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -37,16 +38,16 @@ type LoggerInterface interface {
 	Tracef(format string, params ...interface{})
 	Debugf(format string, params ...interface{})
 	Infof(format string, params ...interface{})
-	Warnf(format string, params ...interface{})
-	Errorf(format string, params ...interface{})
-	Criticalf(format string, params ...interface{})
+	Warnf(format string, params ...interface{}) error
+	Errorf(format string, params ...interface{}) error
+	Criticalf(format string, params ...interface{}) error
 
 	Trace(v ...interface{})
 	Debug(v ...interface{})
 	Info(v ...interface{})
-	Warn(v ...interface{})
-	Error(v ...interface{})
-	Critical(v ...interface{})
+	Warn(v ...interface{}) error
+	Error(v ...interface{}) error
+	Critical(v ...interface{}) error
 
 	traceWithCallDepth(callDepth int, message fmt.Stringer)
 	debugWithCallDepth(callDepth int, message fmt.Stringer)
@@ -102,16 +103,22 @@ func (cLogger *commonLogger) Infof(format string, params ...interface{}) {
 	cLogger.infoWithCallDepth(loggerFuncCallDepth, newLogFormattedMessage(format, params))
 }
 
-func (cLogger *commonLogger) Warnf(format string, params ...interface{}) {
-	cLogger.warnWithCallDepth(loggerFuncCallDepth, newLogFormattedMessage(format, params))
+func (cLogger *commonLogger) Warnf(format string, params ...interface{}) error {
+	message := newLogFormattedMessage(format, params)
+	cLogger.warnWithCallDepth(loggerFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
-func (cLogger *commonLogger) Errorf(format string, params ...interface{}) {
-	cLogger.errorWithCallDepth(loggerFuncCallDepth, newLogFormattedMessage(format, params))
+func (cLogger *commonLogger) Errorf(format string, params ...interface{}) error {
+	message := newLogFormattedMessage(format, params)
+	cLogger.errorWithCallDepth(loggerFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
-func (cLogger *commonLogger) Criticalf(format string, params ...interface{}) {
-	cLogger.criticalWithCallDepth(loggerFuncCallDepth, newLogFormattedMessage(format, params))
+func (cLogger *commonLogger) Criticalf(format string, params ...interface{}) error {
+	message := newLogFormattedMessage(format, params)
+	cLogger.criticalWithCallDepth(loggerFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 func (cLogger *commonLogger) Trace(v ...interface{}) {
@@ -126,16 +133,22 @@ func (cLogger *commonLogger) Info(v ...interface{}) {
 	cLogger.infoWithCallDepth(loggerFuncCallDepth, newLogMessage(v))
 }
 
-func (cLogger *commonLogger) Warn(v ...interface{}) {
-	cLogger.warnWithCallDepth(loggerFuncCallDepth, newLogMessage(v))
+func (cLogger *commonLogger) Warn(v ...interface{}) error {
+	message := newLogMessage(v)
+	cLogger.warnWithCallDepth(loggerFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
-func (cLogger *commonLogger) Error(v ...interface{}) {
-	cLogger.errorWithCallDepth(loggerFuncCallDepth, newLogMessage(v))
+func (cLogger *commonLogger) Error(v ...interface{}) error {
+	message := newLogMessage(v)
+	cLogger.errorWithCallDepth(loggerFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
-func (cLogger *commonLogger) Critical(v ...interface{}) {
-	cLogger.criticalWithCallDepth(loggerFuncCallDepth, newLogMessage(v))
+func (cLogger *commonLogger) Critical(v ...interface{}) error {
+	message := newLogMessage(v)
+	cLogger.criticalWithCallDepth(loggerFuncCallDepth, message)
+	return errors.New(message.String())
 }
 
 func (cLogger *commonLogger) traceWithCallDepth(callDepth int, message fmt.Stringer) {
@@ -188,7 +201,7 @@ func (cLogger *commonLogger) fillUnusedLevelsByContraint(constraint logLevelCons
 }
 
 // stackCallDepth is used to indicate the call depth of 'log' func.
-// This depth level is used in the runtime.Caller(...) call. See 
+// This depth level is used in the runtime.Caller(...) call. See
 // common_context.go -> specificContext, extractCallerInfo for details.
 func (cLogger *commonLogger) log(
 	level LogLevel,
@@ -206,7 +219,7 @@ func (cLogger *commonLogger) log(
 	context, _ := specificContext(stackCallDepth)
 
 	// Context errors are not reported because there are situations
-	// in which context errors are normal Seelog usage cases. For 
+	// in which context errors are normal Seelog usage cases. For
 	// example in executables with stripped symbols.
 	// Error contexts are returned instead. See common_context.go.
 	/*if err != nil {


### PR DESCRIPTION
Warn, Error and Critical methods now return an error for log4go compatibility
