### PR TITLE
Moved locking to prevent race conditions

### DIFF
--- a/behavior_asynclogger.go
+++ b/behavior_asynclogger.go
@@ -1,16 +1,16 @@
 // Copyright (c) 2012 - Cloud Instruments Co., Ltd.
-// 
+//
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met: 
-// 
+// modification, are permitted provided that the following conditions are met:
+//
 // 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer. 
+//    list of conditions and the following disclaimer.
 // 2. Redistributions in binary form must reproduce the above copyright notice,
 //    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution. 
-// 
+//    and/or other materials provided with the distribution.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,9 +26,9 @@ package seelog
 
 import (
 	"container/list"
-	"sync"
-	"fmt"
 	"errors"
+	"fmt"
+	"sync"
 )
 
 // MaxQueueSize is the critical number of messages in the queue that result in an immediate flush.
@@ -39,7 +39,7 @@ const (
 type msgQueueItem struct {
 	level   LogLevel
 	context logContextInterface
-	message  fmt.Stringer
+	message fmt.Stringer
 }
 
 // asyncLogger represents common data for all asynchronous loggers
@@ -119,15 +119,15 @@ func (asnLogger *asyncLogger) addMsgToQueue(
 	defer asnLogger.queueMutex.Unlock()
 
 	if !asnLogger.closed {
+		asnLogger.queueHasElements.L.Lock()
+		defer asnLogger.queueHasElements.L.Unlock()
+
 		if asnLogger.msgQueue.Len() >= MaxQueueSize {
 			fmt.Printf("Seelog queue overflow: more than %v messages in the queue. Flushing.\n", MaxQueueSize)
 			asnLogger.flushQueue()
 		}
-		
-		queueItem := msgQueueItem{level, context, message}
 
-		asnLogger.queueHasElements.L.Lock()
-		defer asnLogger.queueHasElements.L.Unlock()
+		queueItem := msgQueueItem{level, context, message}
 
 		asnLogger.msgQueue.PushBack(queueItem)
 		asnLogger.queueHasElements.Broadcast()


### PR DESCRIPTION
When testing my application with the new -race flag in Go 1.1 I found a race condition in seelog. This pull request will prevent that by just moving the locking above the Len() call.
