### PR TITLE
write internal errors to Stderr not the console

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -27,11 +27,12 @@ package seelog
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 )
 
 func reportInternalError(err error) {
-	fmt.Println("Seelog error: " + err.Error())
+	fmt.Fprintln(os.Stderr, "Seelog error: "+err.Error())
 }
 
 // LoggerInterface represents structs capable of logging Seelog messages


### PR DESCRIPTION
When there are internal errors, the errors should get written to Stderr not to Stdout. Also, writing to stdout causes the consistent formatting of the error formatters to be broken.  