### PR TITLE
fix: weird path, and renaming error

### DIFF
--- a/common_context.go
+++ b/common_context.go
@@ -87,6 +87,11 @@ func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName st
 	fullPath = strings.Replace(fullPath, "\\", string(os.PathSeparator), -1)
 	fullPath = strings.Replace(fullPath, "/", string(os.PathSeparator), -1)
 
+	// fix: weird path:  \\psf\gopath\src\github.com\cihub\seelog/\\psf\gopath\src\github.com\cihub\seelog\format_test.go
+	if strings.HasPrefix(fullPath, workingDir) && strings.Count(fullPath, workingDir) == 2 {
+		fullPath = fullPath[len(workingDir):]
+	}
+
 	if strings.HasPrefix(fullPath, workingDir) {
 		shortPath = fullPath[len(workingDir):]
 	} else {
@@ -95,6 +100,7 @@ func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName st
 
 	funName := runtime.FuncForPC(pc).Name()
 	var functionName string
+
 	if strings.HasPrefix(funName, workingDir) {
 		functionName = funName[len(workingDir):]
 	} else {

--- a/common_context.go
+++ b/common_context.go
@@ -27,7 +27,6 @@ package seelog
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -77,12 +76,6 @@ func currentContext() (LogContextInterface, error) {
 }
 
 func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName string, lineNumber int, err error) {
-	f, err := os.OpenFile("c:\\var\\log\\seelog.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err == nil {
-		defer f.Close()
-		log.SetOutput(f)
-	}
-
 	pc, fullPath, line, ok := runtime.Caller(skip)
 
 	if !ok {
@@ -104,8 +97,6 @@ func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName st
 			fullPath = fullPath[len(prefix)+1:]
 		}
 	}
-
-	log.Printf("wid: %d, sep: %s, fullPath: %s, workingDir: %s", wid, sep, fullPath, workingDir)
 
 	if strings.HasPrefix(fullPath, workingDir) {
 		shortPath = fullPath[len(workingDir):]
@@ -131,13 +122,6 @@ func extractCallerInfo(skip int) (fullPath string, shortPath string, funcName st
 // occurs, the returned context is an error context, which contains no paths
 // or names, but states that they can't be extracted.
 func specificContext(skip int) (LogContextInterface, error) {
-	f, err := os.OpenFile("c:\\var\\log\\seelog.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err == nil {
-		defer f.Close()
-		log.SetOutput(f)
-	}
-	// log.Println("specificContext")
-
 	callTime := time.Now()
 
 	if skip < 0 {
@@ -146,7 +130,6 @@ func specificContext(skip int) (LogContextInterface, error) {
 	}
 
 	fullPath, shortPath, function, line, err := extractCallerInfo(skip + 2)
-	log.Printf("specificContext: fullpath: %s, shortPath: %s, func: %s", fullPath, shortPath, function)
 	if err != nil {
 		return &errorContext{callTime, err}, err
 	}

--- a/writers_rollingfilewriter.go
+++ b/writers_rollingfilewriter.go
@@ -320,10 +320,13 @@ func (rw *rollingFileWriter) deleteOldRolls(history []string) error {
 	// In all cases (archive files or not) the files should be deleted.
 	for i := 0; i < rollsToDelete; i++ {
 		rollPath := filepath.Join(rw.currentDirPath, history[i])
-		err := tryRemoveFile(rollPath)
-		if err != nil {
-			return err
-		}
+		// it's better to try best to delete files rather than break the whole loop.
+		tryRemoveFile(rollPath)
+
+		// err := tryRemoveFile(rollPath)
+		// if err != nil {
+		// 	return err
+		// }
 	}
 
 	return nil


### PR DESCRIPTION
1. weird path:
    
    // fix: weird path:      \\psf\gopath\src\github.com\cihub\seelog/\\psf\gopath\src\github.com\cihub\seelog\format_test.go


2. renaming error while log rotate:
    
    // on windows service. (tracked with systeminternal suite.) only our service (single process),
// SYSTEM and explorer.exe are using the log file. but still, an error will be raised while
// renaming it:
//
//     The process cannot access the file because it is being used by another process.
//
// I consulted with some one who implemented windows service with python also encountered the
// some issue. then find out their solution seems pretty stable, although it's not the
// ideal way to fix the issue.
