### PR TITLE
Protect access to the internal 'closed' flag of loggers

### DIFF
--- a/behavior_adaptivelogger.go
+++ b/behavior_adaptivelogger.go
@@ -90,11 +90,11 @@ func (asnAdaptiveLogger *asyncAdaptiveLogger) processItem() (closed bool, itemCo
 	asnAdaptiveLogger.queueHasElements.L.Lock()
 	defer asnAdaptiveLogger.queueHasElements.L.Unlock()
 
-	for asnAdaptiveLogger.msgQueue.Len() == 0 && !asnAdaptiveLogger.closed {
+	for asnAdaptiveLogger.msgQueue.Len() == 0 && !asnAdaptiveLogger.Closed() {
 		asnAdaptiveLogger.queueHasElements.Wait()
 	}
 
-	if asnAdaptiveLogger.closed {
+	if asnAdaptiveLogger.Closed() {
 		return true, asnAdaptiveLogger.msgQueue.Len()
 	}
 
@@ -115,7 +115,7 @@ func (asnAdaptiveLogger *asyncAdaptiveLogger) calcAdaptiveInterval(msgCount int)
 }
 
 func (asnAdaptiveLogger *asyncAdaptiveLogger) processQueue() {
-	for !asnAdaptiveLogger.closed {
+	for !asnAdaptiveLogger.Closed() {
 		closed, itemCount := asnAdaptiveLogger.processItem()
 
 		if closed {

--- a/behavior_asynclogger.go
+++ b/behavior_asynclogger.go
@@ -72,7 +72,7 @@ func (asnLogger *asyncLogger) Close() {
 	asnLogger.m.Lock()
 	defer asnLogger.m.Unlock()
 
-	if !asnLogger.closed {
+	if !asnLogger.Closed() {
 		asnLogger.flushQueue(true)
 		asnLogger.config.RootDispatcher.Flush()
 
@@ -80,7 +80,9 @@ func (asnLogger *asyncLogger) Close() {
 			reportInternalError(err)
 		}
 
+		asnLogger.closedM.Lock()
 		asnLogger.closed = true
+		asnLogger.closedM.Unlock()
 		asnLogger.queueHasElements.Broadcast()
 	}
 }
@@ -89,7 +91,7 @@ func (asnLogger *asyncLogger) Flush() {
 	asnLogger.m.Lock()
 	defer asnLogger.m.Unlock()
 
-	if !asnLogger.closed {
+	if !asnLogger.Closed() {
 		asnLogger.flushQueue(true)
 		asnLogger.config.RootDispatcher.Flush()
 	}
@@ -120,7 +122,7 @@ func (asnLogger *asyncLogger) addMsgToQueue(
 	context LogContextInterface,
 	message fmt.Stringer) {
 
-	if !asnLogger.closed {
+	if !asnLogger.Closed() {
 		asnLogger.queueHasElements.L.Lock()
 		defer asnLogger.queueHasElements.L.Unlock()
 

--- a/behavior_asynclooplogger.go
+++ b/behavior_asynclooplogger.go
@@ -46,11 +46,11 @@ func (asnLoopLogger *asyncLoopLogger) processItem() (closed bool) {
 	asnLoopLogger.queueHasElements.L.Lock()
 	defer asnLoopLogger.queueHasElements.L.Unlock()
 
-	for asnLoopLogger.msgQueue.Len() == 0 && !asnLoopLogger.closed {
+	for asnLoopLogger.msgQueue.Len() == 0 && !asnLoopLogger.Closed() {
 		asnLoopLogger.queueHasElements.Wait()
 	}
 
-	if asnLoopLogger.closed {
+	if asnLoopLogger.Closed() {
 		return true
 	}
 
@@ -59,7 +59,7 @@ func (asnLoopLogger *asyncLoopLogger) processItem() (closed bool) {
 }
 
 func (asnLoopLogger *asyncLoopLogger) processQueue() {
-	for !asnLoopLogger.closed {
+	for !asnLoopLogger.Closed() {
 		closed := asnLoopLogger.processItem()
 
 		if closed {

--- a/behavior_asynctimerlogger.go
+++ b/behavior_asynctimerlogger.go
@@ -57,11 +57,11 @@ func (asnTimerLogger *asyncTimerLogger) processItem() (closed bool) {
 	asnTimerLogger.queueHasElements.L.Lock()
 	defer asnTimerLogger.queueHasElements.L.Unlock()
 
-	for asnTimerLogger.msgQueue.Len() == 0 && !asnTimerLogger.closed {
+	for asnTimerLogger.msgQueue.Len() == 0 && !asnTimerLogger.Closed() {
 		asnTimerLogger.queueHasElements.Wait()
 	}
 
-	if asnTimerLogger.closed {
+	if asnTimerLogger.Closed() {
 		return true
 	}
 
@@ -70,7 +70,7 @@ func (asnTimerLogger *asyncTimerLogger) processItem() (closed bool) {
 }
 
 func (asnTimerLogger *asyncTimerLogger) processQueue() {
-	for !asnTimerLogger.closed {
+	for !asnTimerLogger.Closed() {
 		closed := asnTimerLogger.processItem()
 
 		if closed {

--- a/behavior_synclogger.go
+++ b/behavior_synclogger.go
@@ -55,11 +55,13 @@ func (syncLogger *syncLogger) Close() {
 	syncLogger.m.Lock()
 	defer syncLogger.m.Unlock()
 
-	if !syncLogger.closed {
+	if !syncLogger.Closed() {
 		if err := syncLogger.config.RootDispatcher.Close(); err != nil {
 			reportInternalError(err)
 		}
+		syncLogger.closedM.Lock()
 		syncLogger.closed = true
+		syncLogger.closedM.Unlock()
 	}
 }
 
@@ -67,7 +69,7 @@ func (syncLogger *syncLogger) Flush() {
 	syncLogger.m.Lock()
 	defer syncLogger.m.Unlock()
 
-	if !syncLogger.closed {
+	if !syncLogger.Closed() {
 		syncLogger.config.RootDispatcher.Flush()
 	}
 }


### PR DESCRIPTION
Loggers do not currently synchronise access their internal `closed` flag. As such, asynchronous loggers in particular can encounter data races accessing it. With the [recent commit](https://github.com/cihub/seelog/commit/5173ff817d9732907f6171ea007a2eee57a5a346) to properly set this variable, the problem shows up all the time during our CI tests (which run with the race detector enabled, and which replace loggers).

I chose not to use the existing `m` mutex, since it's not an `RWMutex` and the entire logger doesn't need to be locked to check the one variable.