### PR TITLE
As of 2015-09-02 xml.go does not accept -- in xml comment blocks 

### DIFF
--- a/internals_xmlnode_test.go
+++ b/internals_xmlnode_test.go
@@ -115,7 +115,7 @@ func getXMLTests() []xmlNodeTest {
 `
 		testExpected = newNode()
 		testExpected.name = "a"
-		xmlNodeTests = append(xmlNodeTests, xmlNodeTest{testName, testXML, testExpected, false})
+		xmlNodeTests = append(xmlNodeTests, xmlNodeTest{testName, testXML, testExpected, true})
 
 		testName = "Multiple roots"
 		testXML = `<a></a><b></b>`


### PR DESCRIPTION
As of 2015-09-02 xml.go does not accept '--' in comment blocks  

https://github.com/golang/go/commit/97c859f8da0c85c33d0f29ba5e11094d8e691e87