### PR TITLE
Resolve cihub/seelog#110 : explode archived logs

### DIFF
--- a/cfg_parser_test.go
+++ b/cfg_parser_test.go
@@ -269,7 +269,7 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ := NewRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix)
+		testrollingFileWriter, _ := NewRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix, false)
 		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
@@ -286,7 +286,7 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "log.zip", 100, 5, rollingNameModePostfix)
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "log.zip", 100, 5, rollingNameModePostfix, false)
 		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
@@ -303,7 +303,41 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "test.zip", 100, 5, rollingNameModePrefix)
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "test.zip", 100, 5, rollingNameModePrefix, false)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
+		testExpected.LogType = syncloggerTypeFromString
+		testExpected.RootDispatcher = testHeadSplitter
+		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
+
+		testName = "Rolling file writer archive zip exploded"
+		testLogFileName = getTestFileName(testName, "")
+		testConfig = `
+		<seelog type="sync">
+			<outputs>
+				<rollingfile type="size" filename="` + testLogFileName + `" maxsize="100" maxrolls="5" archivetype="zip" archiveexploded="true"/>
+			</outputs>
+		</seelog>`
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected.Exceptions = nil
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "old", 100, 5, rollingNameModePostfix , true)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
+		testExpected.LogType = syncloggerTypeFromString
+		testExpected.RootDispatcher = testHeadSplitter
+		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
+
+		testName = "Rolling file writer archive zip exploded with specified path"
+		testLogFileName = getTestFileName(testName, "")
+		testConfig = `
+		<seelog type="sync">
+			<outputs>
+				<rollingfile namemode="prefix" type="size" filename="` + testLogFileName + `" maxsize="100" maxrolls="5" archivetype="zip" archiveexploded="true" archivepath="test_old_logs"/>
+			</outputs>
+		</seelog>`
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected.Exceptions = nil
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "test_old_logs", 100, 5, rollingNameModePrefix, true)
 		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
@@ -320,7 +354,7 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix)
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveNone, "", 100, 5, rollingNameModePostfix, false)
 		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
@@ -337,7 +371,7 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriterTime, _ := NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalAny, rollingNameModePostfix)
+		testrollingFileWriterTime, _ := NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalAny, rollingNameModePostfix, false)
 		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriterTime})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter
@@ -356,7 +390,7 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriterTime, _ = NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePostfix)
+		testrollingFileWriterTime, _ = NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePostfix, false)
 		testbufferedWriter, _ := NewBufferedWriter(testrollingFileWriterTime, 100500, 100)
 		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testbufferedWriter})
 		testExpected.LogType = syncloggerTypeFromString
@@ -987,6 +1021,16 @@ func getParserTests() []parserTest {
 		</seelog>`
 		parserTests = append(parserTests, parserTest{testName, testConfig, nil, true, nil})
 
+		testName = "Errors #27"
+		testLogFileName = getTestFileName(testName, "")
+		testConfig = `
+		<seelog type="sync">
+			<outputs>
+				<rollingfile type="size" filename="` + testLogFileName + `" maxsize="100" maxrolls="5" archivetype="zip" archivepath="" />
+			</outputs>
+		</seelog>`
+		parserTests = append(parserTests, parserTest{testName, testConfig, nil, true, nil})
+
 		testName = "Buffered writer same formatid override"
 		testLogFileName = getTestFileName(testName, "")
 		testConfig = `
@@ -1003,7 +1047,7 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriterTime, _ = NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePrefix)
+		testrollingFileWriterTime, _ = NewRollingFileWriterTime(testLogFileName, rollingArchiveNone, "", 0, "2006-01-02T15:04:05Z07:00", rollingIntervalDaily, rollingNameModePrefix, false)
 		testbufferedWriter, _ = NewBufferedWriter(testrollingFileWriterTime, 100500, 100)
 		testFormat, _ = NewFormatter("%Level %Msg %File 123")
 		formattedWriter, _ = NewFormattedWriter(testbufferedWriter, testFormat)

--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 // File and directory permitions.
@@ -378,7 +379,13 @@ func createZip(archiveName string, files map[string][]byte) error {
 
 	// Write files
 	for fpath, fcont := range files {
-		f, err := w.Create(fpath)
+		header := &zip.FileHeader{
+			Name:   fpath,
+			Method: zip.Deflate,
+		}
+		header.SetModTime(time.Now())
+
+		f, err := w.CreateHeader(header)
 		if err != nil {
 			return err
 		}

--- a/internals_xmlnode_test.go
+++ b/internals_xmlnode_test.go
@@ -110,7 +110,7 @@ func getXMLTests() []xmlNodeTest {
 		testName = "Comments"
 		testXML =
 			`<!-- <abcdef/> -->
-<a> <!-- <!--12345-->
+<a> <!-- 12345-->
 </a>
 `
 		testExpected = newNode()

--- a/writers_filewriter_test.go
+++ b/writers_filewriter_test.go
@@ -52,19 +52,22 @@ func simplefileWriterGetter(testCase *fileWriterTestCase) (io.WriteCloser, error
 
 //===============================================================
 type fileWriterTestCase struct {
-	files       []string
-	fileName    string
-	rollingType rollingType
-	fileSize    int64
-	maxRolls    int
-	datePattern string
-	writeCount  int
-	resFiles    []string
-	nameMode    rollingNameMode
+	files           []string
+	fileName        string
+	rollingType     rollingType
+	fileSize        int64
+	maxRolls        int
+	datePattern     string
+	writeCount      int
+	resFiles        []string
+	nameMode        rollingNameMode
+	archiveType     rollingArchiveType
+	archiveExploded bool
+	archivePath     string
 }
 
 func createSimplefileWriterTestCase(fileName string, writeCount int) *fileWriterTestCase {
-	return &fileWriterTestCase{[]string{}, fileName, rollingTypeSize, 0, 0, "", writeCount, []string{fileName}, 0}
+	return &fileWriterTestCase{[]string{}, fileName, rollingTypeSize, 0, 0, "", writeCount, []string{fileName}, 0, rollingArchiveNone, false, ""}
 }
 
 var simplefileWriterTests = []*fileWriterTestCase{
@@ -90,7 +93,7 @@ func NewFileWriterTester(
 }
 
 func isWriterTestFile(fn string) bool {
-	return strings.Contains(fn, ".testlog")
+	return strings.Contains(fn, ".testlog") || strings.Contains(fn, ".zip")
 }
 
 func cleanupWriterTest(t *testing.T) {


### PR DESCRIPTION
**Why ?**
Popular command line utilities like `zcat` or `zgrep` are useful tools for processing log files. For instance, `zgrep` allow to search compressed files for a regular expression.
Those tools require that the analyzed archive contains only one file. Yet, when compressing archived logs, seelog put all the log files in the same archive.
    
So, The purpose of this pull request is to add the possibility for archived logs to be zipped in dedicated zip files.
    
**How ?**
As new compression formats might be introduced in future release of `seelog`, we want to clearly separate the choice of the compression algorithm to the choice of the gathering mode (grouped vs exploded).
Therefore, we propose a new attribute, `archiveexploded` (a boolean), specifying if the logs should be exploded or grouped inside the same archive file.

**Extra**
We have also fixed two bugs in this pull request :
* Zip entries modification dates is now correctly set
* internals_xmlnode_test.go contained a XML structure identified as incorrect since Go 1.6