### PR TITLE
Add gzip compression format

### DIFF
--- a/cfg_parser.go
+++ b/cfg_parser.go
@@ -1039,10 +1039,9 @@ func createRollingFileWriter(node *xmlNode, formatFromParent *formatter, formats
 					rArchivePath = rollingArchiveDefaultExplodedName
 
 				} else {
-					rArchivePath, ok = rollingArchiveTypesDefaultNames[rArchiveType]
-					if !ok {
-						return nil, fmt.Errorf("cannot get default filename for archive type = %v",
-							rArchiveType)
+					rArchivePath, err = rollingArchiveTypeDefaultName(rArchiveType, false)
+					if err != nil {
+						return nil, err
 					}
 				}
 			}

--- a/cfg_parser_test.go
+++ b/cfg_parser_test.go
@@ -337,7 +337,7 @@ func getParserTests() []parserTest {
 		testExpected = new(configForParsing)
 		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
 		testExpected.Exceptions = nil
-		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "old", 100, 5, rollingNameModePostfix , true)
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveZip, "old", 100, 5, rollingNameModePostfix, true)
 		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
 		testExpected.LogType = syncloggerTypeFromString
 		testExpected.RootDispatcher = testHeadSplitter

--- a/cfg_parser_test.go
+++ b/cfg_parser_test.go
@@ -275,6 +275,23 @@ func getParserTests() []parserTest {
 		testExpected.RootDispatcher = testHeadSplitter
 		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
 
+		testName = "Rolling file writer archive gzip"
+		testLogFileName = getTestFileName(testName, "")
+		testConfig = `
+		<seelog type="sync">
+			<outputs>
+				<rollingfile type="size" filename="` + testLogFileName + `" maxsize="100" maxrolls="5" archivetype="gzip"/>
+			</outputs>
+		</seelog>`
+		testExpected = new(configForParsing)
+		testExpected.Constraints, _ = NewMinMaxConstraints(TraceLvl, CriticalLvl)
+		testExpected.Exceptions = nil
+		testrollingFileWriter, _ = NewRollingFileWriterSize(testLogFileName, rollingArchiveGzip, "log.tar.gz", 100, 5, rollingNameModePostfix, false)
+		testHeadSplitter, _ = NewSplitDispatcher(DefaultFormatter, []interface{}{testrollingFileWriter})
+		testExpected.LogType = syncloggerTypeFromString
+		testExpected.RootDispatcher = testHeadSplitter
+		parserTests = append(parserTests, parserTest{testName, testConfig, testExpected, false, nil})
+
 		testName = "Rolling file writer archive zip"
 		testLogFileName = getTestFileName(testName, "")
 		testConfig = `

--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+	"compress/gzip"
+	"archive/tar"
 )
 
 // File and directory permitions.
@@ -407,4 +409,112 @@ func createZip(archiveName string, files map[string][]byte) error {
 	}
 
 	return nil
+}
+
+func createTar(files map[string][]byte) ([]byte, error) {
+
+	// Create a buffer to write our archive to.
+	tarBuffer := new(bytes.Buffer)
+	tarWriter := tar.NewWriter(tarBuffer)
+
+	for fpath, fcont := range files {
+
+		header := &tar.Header{
+			Name:   fpath,
+			Size: int64(len(fcont)),
+			Mode: defaultFilePermissions,
+			ModTime: time.Now(),
+		}
+
+		err := tarWriter.WriteHeader(header)
+
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = tarWriter.Write(fcont)
+		if err != nil {
+			return nil, err
+		}
+	}
+	tarWriter.Close()
+
+	return tarBuffer.Bytes(), nil
+}
+
+func unTar(data []byte) (map[string][]byte, error) {
+	tarReader := tar.NewReader(bytes.NewReader(data))
+	files := make(map[string][]byte)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		info := header.FileInfo()
+		if info.IsDir() {
+			continue
+		}
+		buffer := new(bytes.Buffer)
+		_, err =io.Copy(buffer, tarReader)
+		files[header.Name] = buffer.Bytes()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return files, nil
+
+}
+
+func createGzip(archiveName string, content []byte) error {
+
+	// Create a buffer to write our archive to.
+	// Make sure to check the error on Close.
+	gzipBuffer := new(bytes.Buffer)
+	gzipWriter := gzip.NewWriter(gzipBuffer)
+
+	_, err := gzipWriter.Write(content)
+	if err != nil {
+		return err
+	}
+	err = gzipWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(archiveName, gzipBuffer.Bytes(), defaultFilePermissions)
+
+}
+
+func unGzip(filename string) ([]byte, error) {
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+
+	content := new(bytes.Buffer)
+	byteBuffer := make([]byte, 1000)
+	byteRead := 0
+	for {
+		byteRead, err = reader.Read(byteBuffer)
+		if err == io.EOF {
+			break;
+		}
+		content.Write(byteBuffer[0:byteRead])
+
+	}
+	reader.Close()
+	return content.Bytes(), nil
+
 }

--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -1,8 +1,10 @@
 package seelog
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,8 +12,6 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
-	"compress/gzip"
-	"archive/tar"
 )
 
 // File and directory permitions.
@@ -420,9 +420,9 @@ func createTar(files map[string][]byte) ([]byte, error) {
 	for fpath, fcont := range files {
 
 		header := &tar.Header{
-			Name:   fpath,
-			Size: int64(len(fcont)),
-			Mode: defaultFilePermissions,
+			Name:    fpath,
+			Size:    int64(len(fcont)),
+			Mode:    defaultFilePermissions,
 			ModTime: time.Now(),
 		}
 
@@ -459,7 +459,7 @@ func unTar(data []byte) (map[string][]byte, error) {
 			continue
 		}
 		buffer := new(bytes.Buffer)
-		_, err =io.Copy(buffer, tarReader)
+		_, err = io.Copy(buffer, tarReader)
 		files[header.Name] = buffer.Bytes()
 		if err != nil {
 			return nil, err
@@ -509,7 +509,7 @@ func unGzip(filename string) ([]byte, error) {
 	for {
 		byteRead, err = reader.Read(byteBuffer)
 		if err == io.EOF {
-			break;
+			break
 		}
 		content.Write(byteBuffer[0:byteRead])
 
@@ -517,4 +517,9 @@ func unGzip(filename string) ([]byte, error) {
 	reader.Close()
 	return content.Bytes(), nil
 
+}
+
+func isTar(data []byte) bool {
+	tarMagicNumbers := []byte{'\x75', '\x73', '\x74', '\x61', '\x72'}
+	return bytes.Equal(data[257:262], tarMagicNumbers)
 }

--- a/internals_fsutils_test.go
+++ b/internals_fsutils_test.go
@@ -1,11 +1,9 @@
 package seelog
 
 import (
-	"testing"
-	"fmt"
 	"reflect"
+	"testing"
 )
-
 
 func TestGzip(t *testing.T) {
 	defer cleanupWriterTest(t)
@@ -14,19 +12,17 @@ func TestGzip(t *testing.T) {
 	files["file1"] = []byte("I am a log")
 	err := createGzip("./gzip.gz", files["file1"])
 	if err != nil {
-		fmt.Println(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	decompressedFile, err := unGzip("./gzip.gz")
 	if err != nil {
-		fmt.Println(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	equal := reflect.DeepEqual(files["file1"], decompressedFile)
 	if !equal {
-		t.Fail()
+		t.Fatal("gzip(ungzip(file)) should be equal to file")
 	}
 }
 
@@ -35,11 +31,29 @@ func TestTar(t *testing.T) {
 	files := make(map[string][]byte)
 	files["file1"] = []byte("I am a log")
 	files["file2"] = []byte("I am another log")
-	tar, _ := createTar(files)
+	tar, err := createTar(files)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	resultFiles, _ := unTar(tar)
+	resultFiles, err := unTar(tar)
+	if err != nil {
+		t.Fatal(err)
+	}
 	equal := reflect.DeepEqual(files, resultFiles)
 	if !equal {
-		t.Fail()
+		t.Fatal("untar(tar(files)) should be equal to files")
+	}
+}
+
+func TestIsTar(t *testing.T) {
+	defer cleanupWriterTest(t)
+	files := make(map[string][]byte)
+	files["file1"] = []byte("I am a log")
+	files["file2"] = []byte("I am another log")
+	tar, _ := createTar(files)
+
+	if !isTar(tar) {
+		t.Fatal("tar(files) should be recognized as a tar file")
 	}
 }

--- a/internals_fsutils_test.go
+++ b/internals_fsutils_test.go
@@ -1,0 +1,45 @@
+package seelog
+
+import (
+	"testing"
+	"fmt"
+	"reflect"
+)
+
+
+func TestGzip(t *testing.T) {
+	defer cleanupWriterTest(t)
+
+	files := make(map[string][]byte)
+	files["file1"] = []byte("I am a log")
+	err := createGzip("./gzip.gz", files["file1"])
+	if err != nil {
+		fmt.Println(err)
+		t.Fail()
+	}
+
+	decompressedFiles, err := unGzip("./gzip.gz")
+	if err != nil {
+		fmt.Println(err)
+		t.Fail()
+	}
+
+	equal := reflect.DeepEqual(files["file1"], decompressedFiles)
+	if !equal {
+		t.Fail()
+	}
+}
+
+func TestTar(t *testing.T) {
+	defer cleanupWriterTest(t)
+	files := make(map[string][]byte)
+	files["file1"] = []byte("I am a log")
+	files["file2"] = []byte("I am another log")
+	tar, _ := createTar(files)
+
+	resultFiles, _ := unTar(tar)
+	equal := reflect.DeepEqual(files, resultFiles)
+	if !equal {
+		t.Fail()
+	}
+}

--- a/internals_fsutils_test.go
+++ b/internals_fsutils_test.go
@@ -18,13 +18,13 @@ func TestGzip(t *testing.T) {
 		t.Fail()
 	}
 
-	decompressedFiles, err := unGzip("./gzip.gz")
+	decompressedFile, err := unGzip("./gzip.gz")
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
 	}
 
-	equal := reflect.DeepEqual(files["file1"], decompressedFiles)
+	equal := reflect.DeepEqual(files["file1"], decompressedFile)
 	if !equal {
 		t.Fail()
 	}

--- a/writers_filewriter_test.go
+++ b/writers_filewriter_test.go
@@ -93,7 +93,7 @@ func NewFileWriterTester(
 }
 
 func isWriterTestFile(fn string) bool {
-	return strings.Contains(fn, ".testlog") || strings.Contains(fn, ".zip")
+	return strings.Contains(fn, ".testlog") || strings.Contains(fn, ".zip") || strings.Contains(fn, ".gz")
 }
 
 func cleanupWriterTest(t *testing.T) {

--- a/writers_rollingfilewriter_test.go
+++ b/writers_rollingfilewriter_test.go
@@ -61,6 +61,16 @@ func createRollingDatefileWriterTestCase(
 	return &fileWriterTestCase{files, fileName, rollingTypeTime, 0, 0, datePattern, writeCount, resFiles, nameMode, archiveType, archiveExploded, archivePath}
 }
 
+func TestShouldArchiveWithTar(t*testing.T) {
+	compressionType := compressionTypes[rollingArchiveGzip]
+
+	archiveName := compressionType.rollingArchiveTypeName("log", false)
+
+	if archiveName != "log.tar.gz" {
+		t.Fatalf("archive name should be log.tar.gz but got %v", archiveName)
+	}
+}
+
 func TestRollingFileWriter(t *testing.T) {
 	t.Logf("Starting rolling file writer tests")
 	NewFileWriterTester(rollingfileWriterTests, rollingFileWriterGetter, t).test()


### PR DESCRIPTION
Gzip compression format does not directly support compression of multiple files.
When dealing with multiple files, it is required to first collect them into one archive, usually with `tar`, and then compress the result with `gzip`.
    
The new compression format can be selected with 
```properties 
archivetype="gzip"
``` 
option. When combined to 
```properties
archiveexploded="true"
```
, the log files will be directly and individually archived with `gzip`.
Otherwise, the log files will be collected using `tar` and then compressed using `gzip`.
