### PR TITLE
remove unnecessary fs utils

### DIFF
--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -278,15 +278,6 @@ func getOpenFilesByDirectoryAsync(
 	return nil
 }
 
-func copyFile(sf *os.File, dst string) (int64, error) {
-	df, err := os.Create(dst)
-	if err != nil {
-		return 0, err
-	}
-	defer df.Close()
-	return io.Copy(df, sf)
-}
-
 // fileExists return flag whether a given file exists
 // and operation error if an unclassified failure occurs.
 func fileExists(path string) (bool, error) {
@@ -502,21 +493,9 @@ func unGzip(filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 
-	content := new(bytes.Buffer)
-	byteBuffer := make([]byte, 1000)
-	byteRead := 0
-	for {
-		byteRead, err = reader.Read(byteBuffer)
-		if err == io.EOF {
-			break
-		}
-		content.Write(byteBuffer[0:byteRead])
-
-	}
-	reader.Close()
-	return content.Bytes(), nil
-
+	return ioutil.ReadAll(reader)
 }
 
 func isTar(data []byte) bool {


### PR DESCRIPTION
this fixes mishandling of `io.EOF` in the hand-rolled buffering, and at the same time removes an unused `copyFile` util.

I stumbled across this problem while trying to get the unit tests working under Go 1.7, which is more aggressive about returning io.EOF with a positive number of bytes read in decompression code. Instead of fixing the `unGzip` method, I just replaced it with `ioutil.ReadAll`.

There is a bigger refactor to make in the compression code around using more streams and fewer byte buffers, as we've seen OOMs caused by large files getting placed on heap into byte arrays ... but this commit fixes a specific bug that seems worth committing now before tackling the larger buffering architecture.