### PR TITLE
reduce passing of byte arrays on the heap

### DIFF
--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-// File and directory permitions.
+// File and directory permissions.
 const (
 	defaultFilePermissions      = 0666
 	defaultDirectoryPermissions = 0767
@@ -45,7 +45,7 @@ func newNotDirectoryError(dname string) *notDirectoryError {
 // Must return 'false' to set aside the given file.
 type fileFilter func(os.FileInfo, *os.File) bool
 
-// filePathFilter is a filtering creteria function for file path.
+// filePathFilter is a filtering criteria function for file path.
 // Must return 'false' to set aside the given file.
 type filePathFilter func(filePath string) bool
 

--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -278,15 +278,6 @@ func getOpenFilesByDirectoryAsync(
 	return nil
 }
 
-func copyFile(sf *os.File, dst string) (int64, error) {
-	df, err := os.Create(dst)
-	if err != nil {
-		return 0, err
-	}
-	defer df.Close()
-	return io.Copy(df, sf)
-}
-
 // fileExists return flag whether a given file exists
 // and operation error if an unclassified failure occurs.
 func fileExists(path string) (bool, error) {
@@ -502,21 +493,9 @@ func unGzip(filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 
-	content := new(bytes.Buffer)
-	byteBuffer := make([]byte, 1000)
-	byteRead := 0
-	for {
-		byteRead, err = reader.Read(byteBuffer)
-		if err == io.EOF {
-			break
-		}
-		content.Write(byteBuffer[0:byteRead])
-
-	}
-	reader.Close()
-	return content.Bytes(), nil
-
+	return ioutil.ReadAll(reader)
 }
 
 func isTar(data []byte) bool {

--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -363,12 +363,16 @@ func unzip(archiveName string) (map[string][]byte, error) {
 }
 
 // Creates a zip file with the specified file names and byte contents.
-func createZip(archiveName string, files map[string][]byte) error {
-	// Create a buffer to write our archive to.
-	buf := new(bytes.Buffer)
+func createZip(archiveName string, files map[string]io.Reader) error {
+
+	archiveFile, err := os.Create(archiveName)
+	if err != nil {
+		return err
+	}
+	defer archiveFile.Close()
 
 	// Create a new zip archive.
-	w := zip.NewWriter(buf)
+	w := zip.NewWriter(archiveFile)
 
 	// Write files
 	for fpath, fcont := range files {
@@ -382,53 +386,51 @@ func createZip(archiveName string, files map[string][]byte) error {
 		if err != nil {
 			return err
 		}
-		_, err = f.Write([]byte(fcont))
+		_, err = io.Copy(f, fcont)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Make sure to check the error on Close.
-	err := w.Close()
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(archiveName, buf.Bytes(), defaultFilePermissions)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// The Close call writes the checksum, so return the error
+	// instead of just deferring it.
+	return w.Close()
 }
 
-func createTar(files map[string][]byte) ([]byte, error) {
+func createTar(files map[string]io.Reader) ([]byte, error) {
 
 	// Create a buffer to write our archive to.
 	tarBuffer := new(bytes.Buffer)
 	tarWriter := tar.NewWriter(tarBuffer)
 
-	for fpath, fcont := range files {
+	for fpath, freader := range files {
+
+		fcontents, err := ioutil.ReadAll(freader)
+		if err != nil {
+			return nil, err
+		}
 
 		header := &tar.Header{
 			Name:    fpath,
-			Size:    int64(len(fcont)),
+			Size:    int64(len(fcontents)),
 			Mode:    defaultFilePermissions,
 			ModTime: time.Now(),
 		}
 
-		err := tarWriter.WriteHeader(header)
-
+		err = tarWriter.WriteHeader(header)
 		if err != nil {
 			return nil, err
 		}
 
-		_, err = tarWriter.Write(fcont)
+		_, err = tarWriter.Write(fcontents)
 		if err != nil {
 			return nil, err
 		}
 	}
-	tarWriter.Close()
+	err := tarWriter.Close()
+	if err != nil {
+		return nil, err
+	}
 
 	return tarBuffer.Bytes(), nil
 }
@@ -461,24 +463,24 @@ func unTar(data []byte) (map[string][]byte, error) {
 
 }
 
-func createGzip(archiveName string, content []byte) error {
+func createGzip(archiveName string, content io.Reader) error {
 
-	// Create a buffer to write our archive to.
-	// Make sure to check the error on Close.
-	gzipBuffer := new(bytes.Buffer)
-	gzipWriter := gzip.NewWriter(gzipBuffer)
-
-	_, err := gzipWriter.Write(content)
+	archiveFile, err := os.Create(archiveName)
 	if err != nil {
 		return err
 	}
-	err = gzipWriter.Close()
+	defer archiveFile.Close()
+
+	gzipWriter := gzip.NewWriter(archiveFile)
+
+	_, err = io.Copy(gzipWriter, content)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(archiveName, gzipBuffer.Bytes(), defaultFilePermissions)
-
+	// The Close call writes the checksum, so return the error
+	// instead of just deferring it.
+	return gzipWriter.Close()
 }
 
 func unGzip(filename string) ([]byte, error) {

--- a/internals_fsutils.go
+++ b/internals_fsutils.go
@@ -375,7 +375,7 @@ func createZip(archiveName string, files map[string]io.Reader) error {
 	w := zip.NewWriter(archiveFile)
 
 	// Write files
-	for fpath, fcont := range files {
+	for fpath, freader := range files {
 		header := &zip.FileHeader{
 			Name:   fpath,
 			Method: zip.Deflate,
@@ -386,8 +386,7 @@ func createZip(archiveName string, files map[string]io.Reader) error {
 		if err != nil {
 			return err
 		}
-		_, err = io.Copy(f, fcont)
-		if err != nil {
+		if _, err := io.Copy(f, freader); err != nil {
 			return err
 		}
 	}
@@ -417,18 +416,15 @@ func createTar(files map[string]io.Reader) ([]byte, error) {
 			ModTime: time.Now(),
 		}
 
-		err = tarWriter.WriteHeader(header)
-		if err != nil {
+		if err := tarWriter.WriteHeader(header); err != nil {
 			return nil, err
 		}
 
-		_, err = tarWriter.Write(fcontents)
-		if err != nil {
+		if _, err := tarWriter.Write(fcontents); err != nil {
 			return nil, err
 		}
 	}
-	err := tarWriter.Close()
-	if err != nil {
+	if err := tarWriter.Close(); err != nil {
 		return nil, err
 	}
 

--- a/internals_fsutils_test.go
+++ b/internals_fsutils_test.go
@@ -1,6 +1,8 @@
 package seelog
 
 import (
+	"bytes"
+	"io"
 	"reflect"
 	"testing"
 )
@@ -10,7 +12,13 @@ func TestGzip(t *testing.T) {
 
 	files := make(map[string][]byte)
 	files["file1"] = []byte("I am a log")
-	err := createGzip("./gzip.gz", files["file1"])
+
+	readers := make(map[string]io.Reader)
+	for fname, fcont := range files {
+		readers[fname] = bytes.NewReader(fcont)
+	}
+
+	err := createGzip("./gzip.gz", readers["file1"])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +39,13 @@ func TestTar(t *testing.T) {
 	files := make(map[string][]byte)
 	files["file1"] = []byte("I am a log")
 	files["file2"] = []byte("I am another log")
-	tar, err := createTar(files)
+
+	readers := make(map[string]io.Reader)
+	for fname, fcont := range files {
+		readers[fname] = bytes.NewReader(fcont)
+	}
+
+	tar, err := createTar(readers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +65,13 @@ func TestIsTar(t *testing.T) {
 	files := make(map[string][]byte)
 	files["file1"] = []byte("I am a log")
 	files["file2"] = []byte("I am another log")
-	tar, _ := createTar(files)
+
+	readers := make(map[string]io.Reader)
+	for fname, fcont := range files {
+		readers[fname] = bytes.NewReader(fcont)
+	}
+
+	tar, _ := createTar(readers)
 
 	if !isTar(tar) {
 		t.Fatal("tar(files) should be recognized as a tar file")

--- a/internals_fsutils_test.go
+++ b/internals_fsutils_test.go
@@ -13,12 +13,12 @@ func TestGzip(t *testing.T) {
 	files := make(map[string][]byte)
 	files["file1"] = []byte("I am a log")
 
-	readers := make(map[string]io.Reader)
+	freaders := make(map[string]io.Reader)
 	for fname, fcont := range files {
-		readers[fname] = bytes.NewReader(fcont)
+		freaders[fname] = bytes.NewReader(fcont)
 	}
 
-	err := createGzip("./gzip.gz", readers["file1"])
+	err := createGzip("./gzip.gz", freaders["file1"])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,12 +40,12 @@ func TestTar(t *testing.T) {
 	files["file1"] = []byte("I am a log")
 	files["file2"] = []byte("I am another log")
 
-	readers := make(map[string]io.Reader)
+	freaders := make(map[string]io.Reader)
 	for fname, fcont := range files {
-		readers[fname] = bytes.NewReader(fcont)
+		freaders[fname] = bytes.NewReader(fcont)
 	}
 
-	tar, err := createTar(readers)
+	tar, err := createTar(freaders)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,12 +66,15 @@ func TestIsTar(t *testing.T) {
 	files["file1"] = []byte("I am a log")
 	files["file2"] = []byte("I am another log")
 
-	readers := make(map[string]io.Reader)
+	freaders := make(map[string]io.Reader)
 	for fname, fcont := range files {
-		readers[fname] = bytes.NewReader(fcont)
+		freaders[fname] = bytes.NewReader(fcont)
 	}
 
-	tar, _ := createTar(readers)
+	tar, err := createTar(freaders)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !isTar(tar) {
 		t.Fatal("tar(files) should be recognized as a tar file")

--- a/writers_rollingfilewriter.go
+++ b/writers_rollingfilewriter.go
@@ -332,14 +332,14 @@ func (rw *rollingFileWriter) createFileAndFolderIfNeeded(first bool) error {
 
 func (rw *rollingFileWriter) archiveExplodedLogs(logFilename string, compressionType compressionType) error {
 	rollPath := filepath.Join(rw.currentDirPath, logFilename)
-	rawFile, err := os.Open(rollPath)
+	rollFile, err := os.Open(rollPath)
 	if err != nil {
 		return err
 	}
-	defer rawFile.Close()
+	defer rollFile.Close()
 
 	entry := make(map[string]io.Reader)
-	entry[logFilename] = rawFile
+	entry[logFilename] = rollFile
 	archiveName := path.Clean(rw.archivePath + "/" + compressionType.rollingArchiveTypeName(logFilename, true))
 
 	// archive entry
@@ -377,13 +377,13 @@ func (rw *rollingFileWriter) archiveUnexplodedLogs(compressionType compressionTy
 		files[rollPath] = bts
 	}
 
-	readers := make(map[string]io.Reader)
+	freaders := make(map[string]io.Reader)
 	for fname, fcont := range files {
-		readers[fname] = bytes.NewReader(fcont)
+		freaders[fname] = bytes.NewReader(fcont)
 	}
 
 	// Put the final file set to archive file.
-	return compressionType.archive(rw.archivePath, readers, false)
+	return compressionType.archive(rw.archivePath, freaders, false)
 }
 
 func (rw *rollingFileWriter) deleteOldRolls(history []string) error {

--- a/writers_rollingfilewriter.go
+++ b/writers_rollingfilewriter.go
@@ -25,7 +25,9 @@
 package seelog
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -102,7 +104,7 @@ var rollingArchiveTypesStringRepresentation = map[rollingArchiveType]string{
 	rollingArchiveGzip: "gzip",
 }
 
-type archive func(archiveName string, files map[string][]byte, exploded bool) error
+type archive func(archiveName string, files map[string]io.Reader, exploded bool) error
 
 type unarchive func(archiveName string) (map[string][]byte, error)
 
@@ -117,7 +119,7 @@ var compressionTypes = map[rollingArchiveType]compressionType{
 	rollingArchiveZip: {
 		extension:             ".zip",
 		handleMultipleEntries: true,
-		archive: func(archiveName string, files map[string][]byte, exploded bool) error {
+		archive: func(archiveName string, files map[string]io.Reader, exploded bool) error {
 			return createZip(archiveName, files)
 		},
 		unarchive: unzip,
@@ -125,7 +127,7 @@ var compressionTypes = map[rollingArchiveType]compressionType{
 	rollingArchiveGzip: {
 		extension:             ".gz",
 		handleMultipleEntries: false,
-		archive: func(archiveName string, files map[string][]byte, exploded bool) error {
+		archive: func(archiveName string, files map[string]io.Reader, exploded bool) error {
 			if exploded {
 				if len(files) != 1 {
 					return fmt.Errorf("Expected only 1 file but got %v file(s)", len(files))
@@ -138,7 +140,7 @@ var compressionTypes = map[rollingArchiveType]compressionType{
 			if err != nil {
 				return err
 			}
-			return createGzip(archiveName, tar)
+			return createGzip(archiveName, bytes.NewReader(tar))
 		},
 		unarchive: func(archiveName string) (map[string][]byte, error) {
 			content, err := unGzip(archiveName)
@@ -330,17 +332,18 @@ func (rw *rollingFileWriter) createFileAndFolderIfNeeded(first bool) error {
 
 func (rw *rollingFileWriter) archiveExplodedLogs(logFilename string, compressionType compressionType) error {
 	rollPath := filepath.Join(rw.currentDirPath, logFilename)
-	bts, err := ioutil.ReadFile(rollPath)
+	rawFile, err := os.Open(rollPath)
 	if err != nil {
 		return err
 	}
+	defer rawFile.Close()
 
-	entry := make(map[string][]byte)
-	entry[logFilename] = bts
-	archiveFile := path.Clean(rw.archivePath + "/" + compressionType.rollingArchiveTypeName(logFilename, true))
+	entry := make(map[string]io.Reader)
+	entry[logFilename] = rawFile
+	archiveName := path.Clean(rw.archivePath + "/" + compressionType.rollingArchiveTypeName(logFilename, true))
 
 	// archive entry
-	return compressionType.archive(archiveFile, entry, true)
+	return compressionType.archive(archiveName, entry, true)
 }
 
 func (rw *rollingFileWriter) archiveUnexplodedLogs(compressionType compressionType, rollsToDelete int, history []string) error {
@@ -374,8 +377,13 @@ func (rw *rollingFileWriter) archiveUnexplodedLogs(compressionType compressionTy
 		files[rollPath] = bts
 	}
 
+	readers := make(map[string]io.Reader)
+	for fname, fcont := range files {
+		readers[fname] = bytes.NewReader(fcont)
+	}
+
 	// Put the final file set to archive file.
-	return compressionType.archive(rw.archivePath, files, false)
+	return compressionType.archive(rw.archivePath, readers, false)
 }
 
 func (rw *rollingFileWriter) deleteOldRolls(history []string) error {


### PR DESCRIPTION
Looking for feedback on both architecture choices as well as making sure all the little details like stream opening/closing are handled properly (there is decent test coverage for these methods, but I'm open to suggestions on writing new test cases).

The goal is to reduce on-heap storage of log files, particularly for the log rotator, which loads the logs it's about to rotate into memory, then compresses them in memory, then writes them to disk. We've seen OOMs because of this (imagine several gigabyte log files being loaded onto the heap on a small EC2 VM, kaboom!), so the strategy I'm trying to spread is to use Readers/Writers whenever possible to stream data from disk through the compression routines back onto disk.

This isn't always possible, particularly in the tar+gz handling, so I kept the changeset conservative, looking for the places where I've seen my own server blow up, and kept byte arrays in place for the more complex edge cases.

Note that this PR depends on #125 (and thus includes it in its commit history).