### PR TITLE
Cache caller info

### DIFF
--- a/common_context_test.go
+++ b/common_context_test.go
@@ -43,7 +43,8 @@ var (
 func init() {
 	// Here we remove the hardcoding of the package name which
 	// may break forks and some CI environments such as jenkins.
-	_, _, funcName, _, _ := extractCallerInfo(1)
+	ctx, _ := extractCallerInfo(1)
+	funcName := ctx.funcName
 	preIndex := strings.Index(funcName, "init·")
 	if preIndex == -1 {
 		preIndex = strings.Index(funcName, "init")


### PR DESCRIPTION
By introducing a cache of caller PC (program counter) to logContext, we
can avoid calling runtime.FuncForPC for each log message. This function
in the runtime package performs a linear search over each function
linked in to the executable, and is thus slow.