### PR TITLE
Always open log files with O_APPEND

### DIFF
--- a/writers_rollingfilewriter.go
+++ b/writers_rollingfilewriter.go
@@ -320,28 +320,21 @@ func (rw *rollingFileWriter) createFileAndFolderIfNeeded(first bool) error {
 	rw.currentName = rw.self.getCurrentFileName()
 	filePath := filepath.Join(rw.currentDirPath, rw.currentName)
 
-	// If exists
-	stat, err := os.Lstat(filePath)
-	if err == nil {
-		rw.currentFile, err = os.OpenFile(filePath, os.O_WRONLY|os.O_APPEND, defaultFilePermissions)
-		if err != nil {
-			return err
-		}
-
-		stat, err = os.Lstat(filePath)
-		if err != nil {
-			return err
-		}
-
-		rw.currentFileSize = stat.Size()
-	} else {
-		rw.currentFile, err = os.Create(filePath)
-		rw.currentFileSize = 0
-	}
+	// This will either open the existing file (without truncating it) or
+	// create if necessary. Append mode avoids any race conditions.
+	rw.currentFile, err = os.OpenFile(filePath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, defaultFilePermissions)
 	if err != nil {
 		return err
 	}
 
+	stat, err := rw.currentFile.Stat()
+	if err != nil {
+		rw.currentFile.Close()
+		rw.currentFile = nil
+		return err
+	}
+
+	rw.currentFileSize = stat.Size()
 	return nil
 }
 


### PR DESCRIPTION
In order to avoid any sort of race condition, always open log files with `O_APPEND`. This resolves problems observed where old content in a log file is being overwritten by a running process.

We have observed this occur in practice several times, although we have not analyzed the root cause. But this change provides a simple safety mechanism to avoid the issue, and simplifies the file creation codepath.