### PR TITLE
Add direct syslog support

### DIFF
--- a/cfg_parser.go
+++ b/cfg_parser.go
@@ -69,6 +69,7 @@ const (
 	subjectID                        = "subject"
 	splitterDispatcherID             = "splitter"
 	consoleWriterID                  = "console"
+	syslogWriterID                   = "syslog"
 	customReceiverID                 = "custom"
 	customNameAttrID                 = "name"
 	customNameDataAttrPrefix         = "data-"
@@ -150,6 +151,7 @@ func init() {
 		customReceiverID:     {createCustomReceiver},
 		filterDispatcherID:   {createFilter},
 		consoleWriterID:      {createConsoleWriter},
+		syslogWriterID:       {createSyslogWriter},
 		rollingfileWriterID:  {createRollingFileWriter},
 		bufferedWriterID:     {createbufferedWriter},
 		smtpWriterID:         {createSMTPWriter},
@@ -913,6 +915,24 @@ func createConsoleWriter(node *xmlNode, formatFromParent *formatter, formats map
 	}
 
 	return NewFormattedWriter(consoleWriter, currentFormat)
+}
+
+func createSyslogWriter(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {
+	if node.hasChildren() {
+		return nil, errNodeCannotHaveChildren
+	}
+
+	err := checkUnexpectedAttribute(node, outputFormatID)
+	if err != nil {
+		return nil, err
+	}
+
+	currentFormat, err := getCurrentFormat(node, predefinedFormats["std:syslog-bsd-local"], formats)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewFormattedWriter(NewSyslogWriter(), currentFormat)
 }
 
 func createconnWriter(node *xmlNode, formatFromParent *formatter, formats map[string]*formatter, cfg *CfgParseParams) (interface{}, error) {

--- a/cfg_parser.go
+++ b/cfg_parser.go
@@ -177,6 +177,10 @@ func fillPredefinedFormats() error {
 		"debug":       `[%LEVEL] %RelFile:%Func.%Line %Date %Time %Msg%n`,
 		"debug-short": `[%LEVEL] %Date %Time %Msg%n`,
 		"fast":        `%Ns %l %Msg%n`,
+
+		"syslog-bsd-local": `%SyslogPriority%Date(Jan _2 15:04:05) %AppName[%PID]: %Msg%n`,
+		"syslog-bsd":       `%SyslogPriority%Date(Jan _2 15:04:05) %Hostname %AppName[%PID]: %Msg%n`,
+		"syslog-rfc5424":   `%SyslogPriority()1%UTCDate(2006-01-25T15:04:05.000000000Z07:00) %Hostname %AppName %PID - - %Msg%n`,
 	}
 
 	predefinedFormats = make(map[string]*formatter)

--- a/format.go
+++ b/format.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"unicode"
@@ -55,6 +56,8 @@ var DefaultMsgFormat = "%Ns [%Level] %Msg%n"
 var (
 	DefaultFormatter *formatter
 	msgonlyformatter *formatter
+
+	formattedHostname, formattedPID string
 )
 
 func init() {
@@ -65,6 +68,10 @@ func init() {
 	if msgonlyformatter, err = NewFormatter("%Msg"); err != nil {
 		reportInternalError(fmt.Errorf("error during creating msgonlyformatter: %s", err))
 	}
+	if formattedHostname, err = os.Hostname(); err != nil {
+		reportInternalError(fmt.Errorf("error querying os.Hostname: %s", err))
+	}
+	formattedPID = fmt.Sprintf("%d", os.Getpid())
 }
 
 // FormatterFunc represents one formatter object that starts with '%' sign in the 'format' attribute
@@ -99,6 +106,8 @@ var formatterFuncs = map[string]FormatterFunc{
 	"UTCTime":   formatterUTCTime,
 	"Ns":        formatterNs,
 	"UTCNs":     formatterUTCNs,
+	"Hostname":  formatterHostname,
+	"PID":       formatterPID,
 	"r":         formatterr,
 	"n":         formattern,
 	"t":         formattert,
@@ -421,6 +430,14 @@ func formatterNs(message string, level LogLevel, context LogContextInterface) in
 
 func formatterUTCNs(message string, level LogLevel, context LogContextInterface) interface{} {
 	return context.CallTime().UTC().UnixNano()
+}
+
+func formatterHostname(message string, level LogLevel, context LogContextInterface) interface{} {
+	return formattedHostname
+}
+
+func formatterPID(message string, level LogLevel, context LogContextInterface) interface{} {
+	return formattedPID
 }
 
 func formatterr(message string, level LogLevel, context LogContextInterface) interface{} {

--- a/format.go
+++ b/format.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
@@ -57,7 +58,7 @@ var (
 	DefaultFormatter *formatter
 	msgonlyformatter *formatter
 
-	formattedHostname, formattedPID string
+	formattedHostname, formattedPID, formattedAppName string
 )
 
 func init() {
@@ -72,6 +73,7 @@ func init() {
 		reportInternalError(fmt.Errorf("error querying os.Hostname: %s", err))
 	}
 	formattedPID = fmt.Sprintf("%d", os.Getpid())
+	formattedAppName = filepath.Base(os.Args[0])
 }
 
 // FormatterFunc represents one formatter object that starts with '%' sign in the 'format' attribute
@@ -108,6 +110,7 @@ var formatterFuncs = map[string]FormatterFunc{
 	"UTCNs":     formatterUTCNs,
 	"Hostname":  formatterHostname,
 	"PID":       formatterPID,
+	"AppName":   formatterAppName,
 	"r":         formatterr,
 	"n":         formattern,
 	"t":         formattert,
@@ -438,6 +441,10 @@ func formatterHostname(message string, level LogLevel, context LogContextInterfa
 
 func formatterPID(message string, level LogLevel, context LogContextInterface) interface{} {
 	return formattedPID
+}
+
+func formatterAppName(message string, level LogLevel, context LogContextInterface) interface{} {
+	return formattedAppName
 }
 
 func formatterr(message string, level LogLevel, context LogContextInterface) interface{} {

--- a/writers_syslog.go
+++ b/writers_syslog.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2012 - Cloud Instruments Co., Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package seelog
+
+import "net"
+
+// NewSyslogWriter returns a connWriter that has been configured to talk to a
+// local syslog daemon. To talk to a remote syslog daemon over the network,
+// simply use a connWriter directly.
+func NewSyslogWriter() *connWriter {
+	// attempt to detect syslog daemon; this code is derived from Go's
+	// own syslog package.
+	netNames := []string{"unixgram", "unix"}
+	addrs := []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
+	for _, netName := range netNames {
+		for _, addr := range addrs {
+			conn, err := net.Dial(netName, addr)
+			if err == nil { // on success
+				conn.Close()
+				return NewConnWriter(netName, addr, false)
+			}
+		}
+	}
+
+	// fall back to sensible default
+	return NewConnWriter("unixgram", "/dev/log", false)
+}


### PR DESCRIPTION
This pull request adds support for writing to syslog directly.

The motivation of this pull request is to provide an easy, consistent way to write to syslog. It's certainly _possible_ to do this already, but it requires additional code (a custom formatter for the priority field) and additional configuration (a format for the syslog message, and the socket address for the syslog daemon). As this code and config needs to be copied+pasted between various projects, it is a tedious and error-prone process, and it would be better for seelog to provide the capability in a much simpler manner.

The minimal usage of the syslog support is a config as follows:

```xml
<seelog>
  <outputs>
    <syslog/>
  </outputs>
</seelog>
```

This will tell seelog to connect to the local syslog daemon (using the same logic as Go's syslog package, where it tries a few different Unix sockets). The `<syslog>` element's behaviour differs in one respect from the norm: it doesn't derive the format from its parent element, but rather uses the new format `std:syslog-bsd-local` (unless overridden with a `formatid=` attribute). Although it is a departure from the behaviour of the other elements, it does minimise the amount of configuration required to get going, which is my primary motivation here.

If writing to a remote syslog daemon is desired, then the existing `<conn>` receiver can be used along with a new predefined format:

```xml
<seelog>
  <outputs>
    <conn net="tcp" addr="sysloghost:5514" formatid="std:syslog-rfc5424"/>
    <!-- std:syslog-bsd is also provided -->
  </outputs>
</seelog>
```

The new formats are defined as follows:
- `syslog-bsd-local`: maps to `%SyslogPriority%Date(Jan _2 15:04:05) %AppName[%PID]: %Msg%n`; this matches what Go/glibc will write to a local syslog daemon, and is the required format for most syslog daemons.
- `syslog-bsd`: as `syslog-bsd-local`except it adds a `%Hostname` after the date. This matches RFC3164. This format is not used locally, but is used when sending syslog entries over the network.
- `syslog-rfc5424`: maps to `%SyslogPriority()1%UTCDate(2006-01-25T15:04:05.000000000Z07:00) %Hostname %AppName %PID - - %Msg%n`; this is a more up-to-date format with innovations such as actually printing the year in the timestamp (and using a sensible RFC3339 timestamp format).

A few new formatters were added to support this:
- `%Hostname` and `%PID` are obvious
- `%AppName` is taken from the file part of `os.Args[0]`, matching the behaviour of glibc/Go
- `%SyslogPriority` is a new formatter that produces the `<PRIORITY>` token required by the syslog protocol. It defaults to using the `LOG_DAEMON` facility and mapping log levels as (`TraceLvl`/`DebugLvl`→`LOG_DEBUG`; `InfoLvl`→`LOG_INFO`, `WarningLvl`→`LOG_WARNING`, `ErrorLvl`→`LOG_ERR`, `CriticalLvl`→`LOG_CRIT`), but can be overridden.

An example configuration where we want to override the facility and log level mapping:

```xml
<seelog>
  <outputs>
    <syslog formatid="my-syslog"/>
  </outputs>
  <formats>
    <format id="my-syslog" format="%SyslogPriority(auth,debug,info,notice,warning,err,alert)%Date(Jan _2 15:04:05) importantd[%PID]: %Msg%n" />
  </formats>
</seelog>
```